### PR TITLE
chore: claude-code permissions/env tweaks and resolved option rename

### DIFF
--- a/hosts/features/optional/network-manager.nix
+++ b/hosts/features/optional/network-manager.nix
@@ -1,10 +1,10 @@
 {
   services.resolved = {
     enable = true;
-    dnssec = "allow-downgrade";
-    dnsovertls = "opportunistic";
-    domains = [ "~." ];
     settings.Resolve = {
+      DNSSEC = "allow-downgrade";
+      DNSOverTLS = "opportunistic";
+      Domains = [ "~." ];
       DNS = [
         "1.1.1.1#cloudflare-dns.com"
         "1.0.0.1#cloudflare-dns.com"

--- a/users/otavio/home/features/claude-code/default.nix
+++ b/users/otavio/home/features/claude-code/default.nix
@@ -48,6 +48,37 @@ in
           "WebFetch(domain:mynixos.com)"
           "WebSearch"
         ];
+        deny = [
+          # .env files
+          "Read(.env*)"
+          "Edit(.env*)"
+          "Bash(cat *.env*)"
+          "Bash(head *.env*)"
+          "Bash(tail *.env*)"
+          "Bash(less *.env*)"
+          "Bash(more *.env*)"
+
+          # secrets/ directory (sops-nix)
+          "Read(secrets/**)"
+          "Edit(secrets/**)"
+          "Read(**/secrets/**)"
+          "Edit(**/secrets/**)"
+          "Bash(cat *secrets/*)"
+          "Bash(head *secrets/*)"
+          "Bash(tail *secrets/*)"
+          "Bash(less *secrets/*)"
+          "Bash(more *secrets/*)"
+
+          # common secret / private-key files
+          "Read(**/*.pem)"
+          "Read(**/*.key)"
+          "Read(**/id_rsa)"
+          "Read(**/id_ed25519)"
+          "Edit(**/*.pem)"
+          "Edit(**/*.key)"
+          "Edit(**/id_rsa)"
+          "Edit(**/id_ed25519)"
+        ];
       };
       statusLine = {
         type = "command";

--- a/users/otavio/home/features/claude-code/default.nix
+++ b/users/otavio/home/features/claude-code/default.nix
@@ -29,7 +29,10 @@ in
     package = claude-code-fhs;
     settings = {
       env = {
+        CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
+        CLAUDE_CODE_EFFORT_LEVEL = "high";
         CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+        CLAUDE_CODE_NO_FLICKER = "1";
       };
       model = "opus";
       voiceEnabled = true;


### PR DESCRIPTION
## Summary
- **claude-code deny rules** — block `Read`/`Edit` and common shell readers on `.env*`, `secrets/**`, and private-key files (`*.pem`, `*.key`, `id_rsa`, `id_ed25519`).
- **claude-code env vars** — set `CLAUDE_CODE_EFFORT_LEVEL=high` (cap reasoning effort below Opus 4.7's `xhigh` default for faster responses), `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`, and `CLAUDE_CODE_NO_FLICKER=1`.
- **services.resolved rename fix** — migrate `dnssec` / `dnsovertls` / `domains` into `settings.Resolve.{DNSSEC, DNSOverTLS, Domains}` to silence the renamed-option warnings from recent nixpkgs.

## Test plan
- [x] `nix flake check` passes on `x86_64-linux`
- [ ] `colmena apply local -n <hostname>` deploys cleanly with no `services.resolved.*` renamed-option warnings
- [ ] After deploy, restart Claude Code and confirm `/effort` shows `high` and the new deny rules appear in `~/.claude/settings.json`