### PR TITLE
ci: drop dead SSH setup and harden workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest
@@ -64,15 +67,6 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-      - uses: webfactory/ssh-agent@v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Configure SSH for Nix daemon
-        run: |
-          sudo mkdir -p /root/.ssh
-          sudo ssh-keyscan github.com | sudo tee /root/.ssh/known_hosts
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" | sudo tee /root/.ssh/id_ed25519 > /dev/null
-          sudo chmod 600 /root/.ssh/id_ed25519
       - run: nix -L build ".#nixosConfigurations.${{ matrix.nixosConfiguration }}.config.system.build.toplevel"
 
   nix:
@@ -89,13 +83,4 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.*') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-      - uses: webfactory/ssh-agent@v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Configure SSH for Nix daemon
-        run: |
-          sudo mkdir -p /root/.ssh
-          sudo ssh-keyscan github.com | sudo tee /root/.ssh/known_hosts
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" | sudo tee /root/.ssh/id_ed25519 > /dev/null
-          sudo chmod 600 /root/.ssh/id_ed25519
       - run: nix -L build ".#homeConfigurations.${{ matrix.homeConfiguration }}.activationPackage"

--- a/.github/workflows/update-flake.yaml
+++ b/.github/workflows/update-flake.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
 
+permissions:
+  contents: read
+
 jobs:
   lockfile:
     runs-on: ubuntu-latest
@@ -13,6 +16,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
       - name: Update flake.lock
+        id: update
         uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/.github/workflows/update-superset.yaml
+++ b/.github/workflows/update-superset.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 6 * * 1' # runs weekly on Monday at 06:00 UTC
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Cleanup of the GitHub Actions workflows after an audit. All actions were already pinned to their latest major versions, so no version bumps were needed — these are correctness/hardening improvements instead.

### Remove dead SSH setup (`ci.yaml`)
The `nixos` and `nix` jobs set up an SSH agent **and** wrote a private key to `/root/.ssh/id_ed25519` "for the Nix daemon". Both are inert:

- `nix-quick-install-action` installs Nix in **single-user mode** (no root daemon), so `/root/.ssh` is never read.
- All 9 flake inputs are **public `github:` references** fetched over HTTPS tarballs — SSH keys play no role in `github:` fetches.
- Authenticated GitHub fetches (rate-limit avoidance) are already handled: `nix-quick-install-action`'s `github_access_token` defaults to `${{ github.token }}`.

Bonus: these jobs no longer depend on `secrets.SSH_PRIVATE_KEY`, which is unavailable to fork PRs.

### Fix broken output reference (`update-flake.yaml`)
The final step echoed `steps.update.outputs.pull-request-number`, but the `update-flake-lock` step had no `id`. Added `id: update` so the output resolves.

### Least-privilege permissions (all three workflows)
Added `permissions: contents: read`. The two update workflows perform writes via the `GH_TOKEN_FOR_UPDATES` PAT, so the default `GITHUB_TOKEN` only needs read.

## Verification
- `actionlint` passes clean on all three workflows.
- No residual `ssh` / `SSH_PRIVATE_KEY` references remain.