### PR TITLE
ci: use client-id for the flake-update App token

### DIFF
--- a/.github/workflows/update-flake.yaml
+++ b/.github/workflows/update-flake.yaml
@@ -18,5 +18,5 @@ jobs:
           install-nix: true
           auto-merge: false
           token-owner: otavio
-          app-id: ${{ secrets.FLAKE_UPDATE_APP_ID }}
+          client-id: ${{ secrets.FLAKE_UPDATE_CLIENT_ID }}
           app-private-key: ${{ secrets.FLAKE_UPDATE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Follow-up to the `ossystems/nix-actions` migration.

`ossystems/nix-actions@v1` now prefers `client-id` over the deprecated `app-id` input (see OSSystems/nix-actions#1). Switching silences the `create-github-app-token` deprecation warning on the weekly flake.lock run.

## Before merging
Set the **`FLAKE_UPDATE_CLIENT_ID`** repo secret to the App's Client ID (`Iv23li…`, from the app settings page). Without it, `client-id` is empty and the token silently falls back to `GITHUB_TOKEN` — so the secret must exist before this merges.

After merge, the now-unused `FLAKE_UPDATE_APP_ID` secret can be deleted.