### PR TITLE
chore: use mkShellNoCC for the dev shell

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -1,5 +1,5 @@
 { pkgs, inputs, ... }:
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   buildInputs = [
     inputs.colmena.packages.${pkgs.stdenv.hostPlatform.system}.colmena
     pkgs.home-manager


### PR DESCRIPTION
The dev shell only provides `colmena`, `home-manager`, and `sops` — none of which need a C compiler. Switch from `mkShell` to `mkShellNoCC` to drop the toolchain from the shell environment.

## Verification

- `nix build .#devShells.x86_64-linux.default` succeeds.
- `nix flake check` → `all checks passed!`