### PR TITLE
fix(backup): let the freshness check report why it failed

### DIFF
--- a/modules/nixos/restic-r2.nix
+++ b/modules/nixos/restic-r2.nix
@@ -19,12 +19,18 @@ let
   freshness = pkgs.writeShellScript "backup-freshness" ''
     set -uo pipefail
 
-    latest=$(${resticBin} snapshots --json --latest 1 \
-      --host ${config.networking.hostName} 2>/dev/null \
-      | ${pkgs.jq}/bin/jq -r '.[0].time // empty')
+    # --no-cache: this only reads metadata, and the unit has no HOME or
+    # XDG_CACHE_HOME for restic to place a cache in.
+    if ! snapshots=$(${resticBin} --no-cache snapshots --json --latest 1 \
+      --host ${config.networking.hostName}); then
+      echo "cannot query the repository, so freshness is unknown" >&2
+      exit 1
+    fi
+
+    latest=$(printf '%s' "$snapshots" | ${pkgs.jq}/bin/jq -r '.[0].time // empty')
 
     if [ -z "$latest" ]; then
-      echo "no snapshot found for this host" >&2
+      echo "the repository has no snapshot for this host" >&2
       exit 1
     fi
 


### PR DESCRIPTION
Found by running the check on `micro` after deploying #239.

The freshness check discarded stderr, so every repository error arrived as
`no snapshot found for this host`. The unit has no `HOME` and no
`XDG_CACHE_HOME`, so restic stopped immediately:

```
unable to open cache: unable to locate cache directory:
neither $XDG_CACHE_HOME nor $HOME are defined
```

`micro` does hold a snapshot, so the report was wrong about the cause. The
backup service does not hit this because the nixpkgs module sets
`RESTIC_CACHE_DIR` for it.

The query reads metadata only, so it runs with `--no-cache`. stderr now reaches
the journal and the alert mail, and a failed query is reported separately from a
repository that holds no snapshot for this host.

## Verification

Run against the environment that produced the fault (`env -i`, no `HOME`):

```
latest snapshot: 2025-03-10T00:00:15-03:00 (517d old)
older than the 3d threshold
```

The check reads the repository and fails for the true reason. 517 days is
correct: no host has written a snapshot since 2025-03-10.