### PR TITLE
fix(backup): wait out the prune instead of failing the run

### DIFF
--- a/modules/nixos/restic-r2.nix
+++ b/modules/nixos/restic-r2.nix
@@ -117,8 +117,10 @@ in
       extraBackupArgs = [
         "--exclude-caches"
         "--exclude-if-present .backup-ignore"
+        # The pruning host holds an exclusive lock for as long as the prune
+        # takes. Wait it out instead of failing the run.
         "--retry-lock"
-        "15m"
+        "3h"
       ] ++ cfg.extraExcludes;
     };
 


### PR DESCRIPTION
The scheduled run on `micro` failed on 2026-08-10:

```
unable to create lock in backend: repository is already locked exclusively
by PID 24760 on miss-marple by root
lock was created at 2026-08-10 00:27:05
Consumed 1.279s CPU time over 15min 4.192s wall clock time
```

`--retry-lock` was `15m`. That covers a brief overlap, not a prune: the prune on
`miss-marple` held the exclusive lock from 00:02:05 to 01:28:09, about 1h26m.
Any host that backs up inside that window fails and sends an alert, every night.
Nightly alerts for a healthy fleet teach the reader to ignore them, which is the
failure this monitoring exists to prevent.

Pruning stays daily, as requested. The wait becomes `3h`, which covers the
measured 1h26m with room for a repository that grows. 2h would have left only
about 34 minutes of margin, and this was the first prune in seventeen months.

`TimeoutStartUSec=infinity` on the unit, so a long wait cannot be killed part
way through.

No data was at risk in the original failure — `micro` already held a snapshot
from 20:03 that evening.

## State of the repository

```
micro:        newest 2026-08-09 20:03   (0d old)
miss-marple:  newest 2026-08-10 00:01   (0d old)
poirot:       newest 2024-09-02         (host unreachable)
```

Freshness checks on both reachable hosts now exit 0, after 517 days of failure.