### PR TITLE
fix(backup): stop the prune from blocking the other two units

### DIFF
--- a/modules/nixos/restic-r2.nix
+++ b/modules/nixos/restic-r2.nix
@@ -19,9 +19,10 @@ let
   freshness = pkgs.writeShellScript "backup-freshness" ''
     set -uo pipefail
 
-    # --no-cache: this only reads metadata, and the unit has no HOME or
-    # XDG_CACHE_HOME for restic to place a cache in.
-    if ! snapshots=$(${resticBin} --no-cache snapshots --json --latest 1 \
+    # --no-cache: the unit has no HOME or XDG_CACHE_HOME for a cache.
+    # --no-lock: reading metadata needs no lock, and the pruning host holds an
+    # exclusive one for as long as the prune takes.
+    if ! snapshots=$(${resticBin} --no-cache --no-lock snapshots --json --latest 1 \
       --host ${config.networking.hostName}); then
       echo "cannot query the repository, so freshness is unknown" >&2
       exit 1
@@ -102,6 +103,9 @@ in
       backupPrepareCommand = "${resticBin} unlock || true";
 
       pruneOpts = lib.optionals cfg.prune [
+        # Backups on other hosts hold a lock while they run, and the prune
+        # needs an exclusive one. Wait for them as they wait for it.
+        "--retry-lock 3h"
         "--keep-daily 7"
         "--keep-weekly 5"
         "--keep-monthly 6"


### PR DESCRIPTION
Both faults come from the exclusive lock the prune holds for as long as it runs.
Neither affected the backups themselves: `micro` and `miss-marple` both hold
snapshots from 2026-08-12.

## The alert was a false alarm

The freshness check takes a lock to read metadata, so it fails whenever it runs
during a prune:

```
unable to create lock in backend: repository is already locked exclusively
by PID 77144 on miss-marple
lock was created at 2026-08-12 00:44:21
```

The prune ran 00:29 to 01:12 and the check fires daily with up to an hour of
jitter, so it lands inside that window most nights. The check now passes
`--no-lock`, which is what the flag is for — it only reads.

## The prune had no retry at all

`--retry-lock 3h` went into `extraBackupArgs`, which reaches the `backup`
command only. The prune is built from `pruneOpts` and got nothing, so the
backup waits for the prune while the prune fails the moment any host is backing
up:

```
unable to create lock in backend: repository is already locked
by PID 3412431 on micro
```

It failed that way on 2026-08-11 and succeeded on 2026-08-12 only because
`micro` finished early. This is the more serious of the two: a prune that keeps
failing means retention never applies and the repository grows without limit.

`--retry-lock 3h` now goes to the prune as well, so the two wait for each other
instead of one always losing.

## Verification

The new check, run in the unit's environment:

```
latest snapshot: 2026-08-12T00:21:56-03:00 (0d old)
```

Exit 0. Evaluated `pruneOpts`:

- `miss-marple`: `["--retry-lock 3h","--keep-daily 7","--keep-weekly 5","--keep-monthly 6","--keep-yearly 0"]`
- `micro`: `[]` — unchanged, it does not prune